### PR TITLE
Upkeep: use rootless nginx + GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+name: Build and publish OCI image
+
+on:
+  push:
+    branches: [master]
+  release:
+    types: [published]
+  pull_request:
+    branches: [master]
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_USER: ${{ github.actor }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Clone
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ env.REGISTRY_PASSWORD }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM nginx:stable-alpine
-MAINTAINER Roch D'Amour <roch.damour@gmail.com>
+FROM nginxinc/nginx-unprivileged:stable-alpine
+
+LABEL org.opencontainers.image.title="Cringy 404 Page"
+LABEL org.opencontainers.image.authors="Roch D'amour <roch.damour@gmail.com>, Nicolas Berbiche <nicolas@normie.dev>"
+LABEL org.opencontainers.image.url="https://github.com/notarock/cringy-404-page"
+LABEL org.opencontainers.image.documentation="https://github.com/notarock/cringy-404-page"
+LABEL org.opencontainers.image.source="https://github.com/notarock/cringy-404-page"
 
 COPY ./index.html /usr/share/nginx/html
 COPY ./404.html /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@ It's that
 ![image](https://user-images.githubusercontent.com/25652765/77218356-e686fe00-6b00-11ea-9e92-bb5bbbc5f71d.png)
 
 nothing more.
+
+## Packaging
+
+1. Clone the repository
+
+2. Build the container
+
+    ``` terminal
+    $ nerdctl build --platform=amd64,arm64 -t registry.example.com/cringy-404-page:latest .
+    ```
+
+    Replace `nerdctl` with your choice of container runtime (podman, docker, etc.).
+
+3. Publish
+
+    ``` terminal
+    $ nerdctl push --all-platforms registry.example.com/cringy-404-page:latest
+    ```


### PR DESCRIPTION
- Switch base nginx image to rootless (unprivileged) image
- Add packaging instructions
- Add github workflow to build and publish OCI image

Uses https://github.com/nginxinc/docker-nginx-unprivileged

edit2: Another thing to note is that the rootless nginx listens on port 8080 instead of port 80